### PR TITLE
Add n7hq.masseffect.com to dark sites

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -573,6 +573,7 @@ mynoise.net
 mypodficacademia.com
 mystere.dev
 n-o-d-e.net
+n7hq.masseffect.com
 nanhu.ca
 nationsglory.com
 nationsglory.es


### PR DESCRIPTION
Add n7hq.masseffect.com to dark sites list.